### PR TITLE
Change URL of the redirection

### DIFF
--- a/da/index.html
+++ b/da/index.html
@@ -7,7 +7,7 @@
 
 	<title>Editeur de diagrammes d'actions (pseudo-code)</title>
 
-	<script>window.location.href = "https://iesn-ig.github.io/da/"</script>
+	<script>window.location.href = "https://section-ig.github.io/da/"</script>
 </head>
 <body>
 </body>


### PR DESCRIPTION
https://iesn-ig.github.io/da does not exist anymore and has been renamed https://section-ig.github.io/da instead.